### PR TITLE
Feedback in settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -911,6 +911,22 @@
         "core-js": "^3.6.4"
       }
     },
+    "@nextcloud/dialogs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-1.2.2.tgz",
+      "integrity": "sha512-N8A8J8UKSvz/hqNcm7gwpm70uAAsx0wurjhdYZ989jaMho+H/Hinjd2jkbV8UnsYYw0x/vWvEX5t6Lwbv08K0g==",
+      "requires": {
+        "core-js": "3.6.4",
+        "toastify-js": "^1.7.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+        }
+      }
+    },
     "@nextcloud/event-bus": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.1.4.tgz",
@@ -7253,6 +7269,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toastify-js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.7.0.tgz",
+      "integrity": "sha512-GmPy4zJ/ulCfmCHlfCtgcB+K2xhx2AXW3T/ZZOSjyjaIGevhz+uvR8HSCTay/wBq4tt2mUnBqlObP1sSWGlsnQ=="
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@nextcloud/axios": "^1.3.2",
+    "@nextcloud/dialogs": "^1.2.2",
     "@nextcloud/initial-state": "^1.1.2",
     "@nextcloud/router": "^1.0.2",
     "@nextcloud/vue": "^1.5.0",

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -26,15 +26,21 @@
             :title="t('riotchat', 'Riot.im configuration')"
             :description="t('riotchat', 'Configure Riot chat here')"
         >
-            <label for="default_server_url">{{ t('riotchat', 'Default server url') }}</label>
+            <label
+                ref="base_url"
+                for="base_url"
+            >{{ t('riotchat', 'Default server url') }}</label>
             <input
-                id="default_server_url"
+                id="base_url"
                 v-model="base_url"
                 type="text"
                 @change="updateSetting('base_url')"
             >
             <br>
-            <label for="default_server_url">{{ t('riotchat', 'Default server name') }}</label>
+            <label
+                ref="server_name"
+                for="server_name"
+            >{{ t('riotchat', 'Default server name') }}</label>
             <input
                 id="default_server_name"
                 v-model="server_name"
@@ -49,7 +55,10 @@
                 class="checkbox"
                 @change="updateSetting('disable_custom_urls')"
             >
-            <label for="disable_custom_urls">{{ t('riotchat', 'Disable custom urls') }}</label>
+            <label
+                ref="disable_custom_urls"
+                for="disable_custom_urls"
+            >{{ t('riotchat', 'Disable custom urls') }}</label>
             <br>
             <input
                 id="disable_login_language_selector"
@@ -58,13 +67,17 @@
                 class="checkbox"
                 @change="updateSetting('disable_login_language_selector')"
             >
-            <label for="disable_login_language_selector">{{ t('riotchat', 'Disable login language selector') }}</label>
+            <label
+                ref="disable_login_language_selector"
+                for="disable_login_language_selector"
+            >{{ t('riotchat', 'Disable login language selector') }}</label>
         </SettingsSection>
     </div>
 </template>
 
 <script>
 import Axios from '@nextcloud/axios';
+import { showError, showSuccess } from '@nextcloud/dialogs';
 import { generateUrl } from '@nextcloud/router';
 import { loadState } from '@nextcloud/initial-state';
 import { SettingsSection } from '@nextcloud/vue';
@@ -84,8 +97,14 @@ export default {
     },
     methods: {
         updateSetting (setting) {
+            const value = this[setting].toString();
+            const settingName = this.$refs[setting].innerText;
             Axios.put(generateUrl(`apps/riotchat/settings/${setting}`), {
-                value: this[setting].toString(),
+                value,
+            }).then(() => {
+                showSuccess(t('riotchat', '{settingName} has been set to {value}', { settingName, value }));
+            }).catch(() => {
+                showError(t('riotchat', '{settingName} could not be set. Try reloading the page.', { settingName }));
             });
         },
     },


### PR DESCRIPTION
It used to be that changing a setting
would give no feedback to the user
as to whether or not the change was
successful.

This commit adds messages that pop up
when a setting has been successfully set.

Signed-off-by: Gary Kim <gary@garykim.dev>