### PR TITLE
Fix release issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dev-setup: 3rdparty/riot
 	npm i
 
 3rdparty/riot: 3rdparty/riot-web
-	(cd 3rdparty/riot-web && npm i && npm run build && cp config.sample.json webapp/ && cp riot.im/develop/config.json webapp/develop.config.json && mv webapp ../riot)
+	(cd 3rdparty/riot-web && npm i && npm i @nextcloud/browserslist-config && npm run build && cp config.sample.json webapp/ && cp riot.im/develop/config.json webapp/develop.config.json && mv webapp ../riot)
 
 .PHONY: build
 build:


### PR DESCRIPTION
Browserslist is getting confused becuase
there is a Node project inside a Node
project. This is a temporary fix that simply
makes the browserslist config available to riot-web.

Makes sense for us since we are only supporting
the same browsers that Nextcloud supports.

Signed-off-by: Gary Kim <gary@garykim.dev>