### PR TITLE
Fix login page issue

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,7 @@ function main () {
     originalTitle = document.title;
 
     iframe = document.getElementById('riot-iframe');
-    if (!window.location.hash && loadState('riotchat', 'disable_custom_urls') === 'true') {
+    if (!window.location.hash && loadState('riotchat', 'disable_custom_urls') === 'true' && !window.localStorage.getItem('mx_user_id')) {
         iframe.src = generateUrl('/apps/riotchat/riot/') + '#/login';
         window.location.hash = '#/login';
     } else {


### PR DESCRIPTION
Currently, the user is sent to the login page
when disable_custom_urls is set regardless
of whether they are logged in or not.

This fixes that issue.

Signed-off-by: Gary Kim <gary@garykim.dev>