### PR TITLE
Respect exit code of lint run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
 	"scripts": {
 		"cs:fix": "php-cs-fixer fix",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
-		"lint": "find . -name \\*.php -not -path './vendor/*' -exec php -l \"{}\" \\;"
+		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/.phan/*' -print0 | xargs -0 -n1 php -l"
 	}
 }


### PR DESCRIPTION
changed from -exec to xargs as this exits properly

Signed-off-by: Gary Kim <gary@garykim.dev>