### PR TITLE
AppController: add default_server_domain to AllowedFrameDomain

### DIFF
--- a/lib/Controller/AppController.php
+++ b/lib/Controller/AppController.php
@@ -60,8 +60,10 @@ class AppController extends Controller {
 		$this->initialStateService->provideInitialState(Application::APP_ID, 'disable_custom_urls',
 			$this->config->getAppValue(Application::APP_ID, 'disable_custom_urls', Application::AvailableSettings['disable_custom_urls']));
 
+		$default_server_domain = $this->config->getAppValue(Application::APP_ID, 'base_url', Application::AvailableSettings['base_url']);
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain($this->request->getServerHost());
+		$csp->addAllowedFrameDomain($default_server_domain);
 		$response->setContentSecurityPolicy($csp);
 
 		$featurePolicy = new FeaturePolicy();


### PR DESCRIPTION
This fixes CSP for SSO logins, tested on firefox ESR 68.9.0 and chromium 83.0.4103.116 with an OpenID Connect provider. 

Error message when clicking on `Sign in with single sign-on`:
```
Content Security Policy: The page’s settings blocked the loading of a resource at https://matrix.example.com/_matrix/client/r0/login/sso/red…ttps%3A%2F%2Fcloud.example.com%2Fapps%2Friotchat%2Friot%2F (“frame-src”).
```