### PR TITLE
Correct link for feature documentation

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -177,7 +177,7 @@ export default {
     computed: {
         featureDocumentation () {
             return t('riotchat', 'These are experimental features in Riot.im that you can enable. For information on what each feature is, check out the documentation for it {linkstart}here{linkend}.')
-                .replace('{linkstart}', `<a href="https://github.com/vector-im/riot-web/blob/${RIOT_WEB_HASH}/docs/feature-flags.md" target="_blank" rel="noopener noreferrer">`)
+                .replace('{linkstart}', `<a href="https://github.com/vector-im/riot-web/blob/${RIOT_WEB_HASH}/docs/labs.md" target="_blank" rel="noopener noreferrer">`)
                 .replace('{linkend}', `</a>`);
         },
         riotWebDocumentation () {


### PR DESCRIPTION
Currently, the link for feature documentation
points to the page about how to add new features
but doesn't list the features currently available
which is more useful for admins.

This commit changes it to point at the documentation
page that describes the currently available lab features.

Signed-off-by: Gary Kim <gary@garykim.dev>