### PR TITLE
fix: sso logins

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,17 @@ function onIframeLoad () {
             iframe.contentWindow.location.hash = window.location.hash;
         }
     };
+
+    // Watch for the localStorage change that indicates that an SSO sign in is being attempted
+    // eslint-disable-next-line no-proto
+    iframe.contentWindow.localStorage.__proto__.setItem = function (...params) {
+        // It looks like an SSO or CAS login is being attempted
+        if (params[0] === "mx_sso_hs_url" && iframe.contentWindow.location.hash === "#/login") {
+            // Kick them to the non-iframed version. A bit jarring but SSO login most likely won't work in the iframe.
+            window.location.href = generateUrl('/apps/riotchat/riot/#/login');
+        }
+        window.localStorage.setItem.apply(this, params);
+    };
 }
 
 function iframeHashChanged () {


### PR DESCRIPTION
fixes: #113
fixes: #227

SSO logins would often not work as they cannot
be iframed a lot of the time. This works around the
issue by trying to detect when the user is attempting
an SSO or CAS login and kicking them to the
non-iframed version to try the login there.

Signed-off-by: Gary Kim <gary@garykim.dev>