### PR TITLE
fix: include changelog in release

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -3,7 +3,6 @@
 /webpack.config.js
 /babel.config.js
 /.idea
-/CHANGELOG.md
 /composer.json
 /composer.lock
 /Makefile
@@ -25,3 +24,4 @@
 /.editorconfig
 /CONTRIBUTING.md
 /.tx/
+/.l10nignore


### PR DESCRIPTION
Include the changelog in the release and also remove `.l10nignore` from the release.