### PR TITLE
Allow adding external domains to CSP header

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,6 +49,7 @@ class Application extends App implements IBootstrap {
 		'set_custom_permalink' => 'false',
 		'sso_immediate_redirect' => 'false',
 		'sso_force_iframe' => 'false',
+                'sso_iframe_domain' => '',
 	];
 
 	public function __construct(array $urlParams = []) {

--- a/lib/Controller/AppController.php
+++ b/lib/Controller/AppController.php
@@ -63,9 +63,18 @@ class AppController extends Controller {
 			$this->config->getAppValue(Application::APP_ID, 'sso_force_iframe', Application::AvailableSettings['sso_force_iframe']));
 
 		$default_server_domain = $this->config->getAppValue(Application::APP_ID, 'base_url', Application::AvailableSettings['base_url']);
+                $custom_sso_iframe_domain = $this->config->getAppValue(Application::APP_ID, 'sso_iframe_domain', Application::AvailableSettings['sso_iframe_domain']);
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain($this->request->getServerHost());
 		$csp->addAllowedFrameDomain($default_server_domain);
+
+                if($custom_sso_iframe_domain !== '') {
+                   $custom_domain_arr = preg_split('/\s+/', $custom_sso_iframe_domain, PREG_SPLIT_NO_EMPTY);
+                   foreach($custom_domain_arr as $tmp_domain) {
+                      $csp->addAllowedFrameDomain($tmp_domain);
+                   }
+                }
+
 		$csp->addAllowedFrameDomain('blob:');
 		$response->setContentSecurityPolicy($csp);
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -90,6 +90,17 @@
                     for="sso_force_iframe"
                 >{{ t('riotchat', 'Disable redirect to non-iframed version for SSO (make sure to set the headers to allow the SSO or CAS to be iframed)') }}</label>
                 <br>
+                <label
+                    ref="sso_iframe_domain"
+                    for="sso_iframe_domain"
+                >{{ t('riotchat', 'External domains allowed to be iframed:') }}</label>
+                <input
+                    id="sso_iframe_domain"
+                    v-model="sso_iframe_domain"
+                    type="text"
+                    @change="updateSetting('sso_iframe_domain')"
+                >
+                <br>
                 <input
                     id="disable_login_language_selector"
                     v-model="disable_login_language_selector"
@@ -245,6 +256,7 @@ export default {
             "set_custom_permalink": loadState('riotchat', 'set_custom_permalink') === 'true',
             "sso_immediate_redirect": loadState('riotchat', 'sso_immediate_redirect') === 'true',
             "sso_force_iframe": loadState('riotchat', 'sso_force_iframe') === 'true',
+            "sso_iframe_domain": loadState('riotchat', 'sso_iframe_domain'),
         };
     },
     computed: {


### PR DESCRIPTION
Fixes #492 

Adds a field in Administrative Settings for defining one or more external domains. Any specified domains use Nextcloud's [addAllowedFrameDomain()](https://nextcloud-server.netlify.app/classes/ocp-appframework-http-emptycontentsecuritypolicy#method_addAllowedFrameDomain) API to modify this app's (and only this app's) Content Security Policy header and add the domain(s) directly to the `frame-src` component of the CSP header. Multiple domains can be specified, separated by spaces, in any format recognized by the [Content Security Policy header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-src#syntax).

NOTE: This PR only addresses what the chat app can control; namely, what domains it's trying to display in an iframe within Nextcloud. It is likely that Matrix servers, SSO login sites, etc. will have their own headers via `X-Frame-Options` or the CSP's `frame-ancestors` section which may need adjustment separately to allow them to work within an iframe across domains.

Screenshot:
<img width="712" height="575" alt="AddDomainsForCSP" src="https://github.com/user-attachments/assets/cc505969-38e5-463d-870d-119783a4dadb" />
