### PR TITLE
fix: auto-redirect to non-iframed version for SSO on more pages

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -59,10 +59,11 @@ function onIframeLoad () {
     // Setting sso_force_iframe (in config) to true forces iframe even if using SSO or CAS login
     if (loadState('riotchat', 'sso_force_iframe') !== 'true') {
         // Watch for the localStorage change that indicates that an SSO sign in is being attempted
+        const ssoInitiationHashes = ['#/login', '#/welcome', '#', ''];
         // eslint-disable-next-line no-proto
         iframe.contentWindow.localStorage.__proto__.setItem = function (...params) {
             // It looks like an SSO or CAS login is being attempted
-            if (params[0] === "mx_sso_hs_url" && iframe.contentWindow.location.hash === "#/login") {
+            if (params[0] === "mx_sso_hs_url" && ssoInitiationHashes.includes(iframe.contentWindow.location.hash)) {
                 // Kick them to the non-iframed version. A bit jarring but SSO login most likely won't work in the iframe.
                 window.location.href = generateUrl('/apps/riotchat/riot/#/login');
             }


### PR DESCRIPTION
Fixes #652

It's possible when sso_immediate_redirect is enabled for the redirect to occur on a page that isn't '#/login' causing the auto-redirect to not trigger. Fix by having it trigger on more possible pages.